### PR TITLE
fix Kindle images exceeding page limit

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -228,6 +228,9 @@ figure {
   background-color: #cccccc;
   border: 1px solid black;
   text-align: center; }
+  figure img {
+    max-width: 80%;
+  }
   figure figcaption {
     text-align: center;
     font-size: 0.8em;

--- a/sass/base.sass
+++ b/sass/base.sass
@@ -251,6 +251,8 @@ figure
   background-color: $sidebar-border-color
   border: 1px solid black
   text-align: center
+  img
+    max-width: 80%
   figcaption
     text-align: center
     font-size: .8em


### PR DESCRIPTION
`figure` environments seem to override the global `img` width constraints by default, letting images flow out of the page margin to the right.
